### PR TITLE
Update action.yaml

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -112,7 +112,7 @@ runs:
 
     - name: Save Artifact
       id: save-artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: pr-${{ github.event.pull_request.number }}-tfplan
         path: ${{ github.workspace }}/${{ inputs.working-directory }}/tfplan


### PR DESCRIPTION
upgraded actions/upload-artifact to v4, under -name: Save Artifact. 

Further Azure testing looks like its related to timing and of each step and was not related to v3 or v4, but did clean up a warning each time this action is run.