### PR TITLE
Adds save-artifact option (defaults false)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A GitHub composite action for generating and posting a terraform plan to a pull 
 | Name | Description | Default | Required |
 |------|-------------|---------|:--------:|
 | debug | Enable `tmate.io` debugging if a failure occurs | `false` | No |
+| save-artifact | Save terraform plan as artifact in Github Action | `false` | No |
 
 ## Outputs
 

--- a/action.yaml
+++ b/action.yaml
@@ -8,6 +8,10 @@ inputs:
   GITHUB_TOKEN:
     description: GitHub token for access to the pull request
     required: true
+  save-artifact:
+    description: Save the terraform plan as an artifact (May contain sensitive data)
+    required: false
+    default: "false"
   working-directory:
     description: Working directory for the `run` actions
     required: false
@@ -116,6 +120,7 @@ runs:
 
     - name: Save Artifact
       id: save-artifact
+      if: ${{ inputs.save-artifact == 'true' }}
       uses: actions/upload-artifact@v4
       with:
         name: pr-${{ github.event.pull_request.number }}-${{ inputs.workflow-artifact-name }}


### PR DESCRIPTION
# Description

This composite action stores tf plan as artifact on server, potentially including secrets. This PR exposed a `haya14busa/action-update-semver` parameter `save-artifact` and defaults it to `"false"` (to not to). Because of this change in default behavior, I think this represents a bump in minor version (if not major).

I tagged it as `v0.1`, but I'm not certain that came across in my push.