### PR TITLE
Feature/new commenter action continued

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -53,69 +53,78 @@ runs:
       with:
         terraform_version: ${{ inputs.terraform-version }}
 
-    - name: install terraform-plan-summary
-      shell: bash
-      run: |
-        REPO="dineshba/terraform-plan-summary"
-        curl -LO https://github.com/$REPO/releases/latest/download/tf-summarize_linux_amd64.tar.gz
-        tmpDir=$(mktemp -d -t tmp.XXXXXXXXXX)
-        mv tf-summarize_linux_amd64.tar.gz $tmpDir
-        cd $tmpDir
-        tar -xzf tf-summarize_linux_amd64.tar.gz
-        chmod +x tf-summarize
-        echo $PWD >> $GITHUB_PATH
+    # - name: install terraform-plan-summary
+    #   shell: bash
+    #   run: |
+    #     REPO="dineshba/terraform-plan-summary"
+    #     curl -LO https://github.com/$REPO/releases/latest/download/tf-summarize_linux_amd64.tar.gz
+    #     tmpDir=$(mktemp -d -t tmp.XXXXXXXXXX)
+    #     mv tf-summarize_linux_amd64.tar.gz $tmpDir
+    #     cd $tmpDir
+    #     tar -xzf tf-summarize_linux_amd64.tar.gz
+    #     chmod +x tf-summarize
+    #     echo $PWD >> $GITHUB_PATH
 
-    - name: Terraform Init
-      id: init
-      shell: bash
-      working-directory: ${{ inputs.working-directory }}
-      run: terraform init ${{ inputs.terraform-init-flags }}
-      continue-on-error: true
+    # - name: Terraform Init
+    #   id: init
+    #   shell: bash
+    #   working-directory: ${{ inputs.working-directory }}
+    #   run: terraform init ${{ inputs.terraform-init-flags }}
+    #   continue-on-error: true
 
-    - name: Post Terraform init failure
-      if: ${{ failure() && (github.event_name == 'pull_request') }}
-      uses: actions/github-script@v7
-      with:
-        github-token: ${{ inputs.GITHUB_TOKEN }}
-        script: |
-          github.rest.issues.createComment({
-            issue_number: context.issue.number,
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            body: `# Terraform Init Failure
-              ## ${{ inputs.header }}
+    # - name: Post Terraform init failure
+    #   if: ${{ failure() && (github.event_name == 'pull_request') }}
+    #   uses: actions/github-script@v7
+    #   with:
+    #     github-token: ${{ inputs.GITHUB_TOKEN }}
+    #     script: |
+    #       github.rest.issues.createComment({
+    #         issue_number: context.issue.number,
+    #         owner: context.repo.owner,
+    #         repo: context.repo.repo,
+    #         body: `# Terraform Init Failure
+    #           ## ${{ inputs.header }}
 
-              ## Details
-              - **Workflow Header**: ${{ inputs.header }}
-              - **Job ID**: ${{ github.job }}
-              - **Step**: terraform init
-              - **Status**: Failed
+    #           ## Details
+    #           - **Workflow Header**: ${{ inputs.header }}
+    #           - **Job ID**: ${{ github.job }}
+    #           - **Step**: terraform init
+    #           - **Status**: Failed
               
 
-              ## Error output
-              ${{ steps.init.outputs.stdout}}
-              ${{ steps.init.outputs.stderr}}`
-          })
-          core.setFailed('The terraform init step failed.');
+    #           ## Error output
+    #           ${{ steps.init.outputs.stdout}}
+    #           ${{ steps.init.outputs.stderr}}`
+    #       })
+    #       core.setFailed('The terraform init step failed.');
           
-    - name: Terraform Plan
-      id: plan
-      shell: bash
-      working-directory: ${{ inputs.working-directory }}
-      env:
-        TF_WORKSPACE: ${{ inputs.terraform-workspace }}
-        TF_IN_AUTOMATION: "true"
-      run: |
-        terraform plan -out=tfplan -input=false ${{ inputs.terraform-plan-flags }}
-      continue-on-error: true
+    # - name: Terraform Plan
+    #   id: plan
+    #   shell: bash
+    #   working-directory: ${{ inputs.working-directory }}
+    #   env:
+    #     TF_WORKSPACE: ${{ inputs.terraform-workspace }}
+    #     TF_IN_AUTOMATION: "true"
+    #   run: |
+    #     terraform plan -out=tfplan -input=false ${{ inputs.terraform-plan-flags }}
+    #   continue-on-error: true
+
+    # - name: Post PR comment
+    #   uses: borchero/terraform-plan-comment@v2
+    #   with:
+    #     header: ${{ inputs.header }}
+    #     token: ${{ inputs.GITHUB_TOKEN }}
+    #     planfile: tfplan
+    #     working-directory: ${{ inputs.working-directory }}
 
     - name: Post PR comment
-      uses: borchero/terraform-plan-comment@v2
+      uses: op5dev/tf-via-pr@v13
       with:
-        header: ${{ inputs.header }}
-        token: ${{ inputs.GITHUB_TOKEN }}
-        planfile: tfplan
+        # Run plan by default, or apply on push to main.
         working-directory: ${{ inputs.working-directory }}
+        command: plan
+        arg-workspace: ${{ inputs.terraform-workspace }}
+        token: ${{ inputs.GITHUB_TOKEN }}
         
     - name: Save Artifact
       id: save-artifact

--- a/action.yaml
+++ b/action.yaml
@@ -115,6 +115,7 @@ runs:
         header: ${{ inputs.header }}
         token: ${{ inputs.GITHUB_TOKEN }}
         planfile: tfplan
+        working-directory: ${{ inputs.working-directory }}
         
     - name: Save Artifact
       id: save-artifact

--- a/action.yaml
+++ b/action.yaml
@@ -32,6 +32,10 @@ inputs:
     description: Provides a unique name to append to the plan artifact attached to this workflow run. Default tfplan
     required: false
     default: "tfplan"
+  header:
+    description: Start all PR comments with this header to unique identify this thread
+    required: false
+    default: "Terraform Plan Output"
 
 
 outputs:
@@ -66,18 +70,34 @@ runs:
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       run: terraform init ${{ inputs.terraform-init-flags }}
+      continue-on-error: true
 
-    - name: Post Init
-      if: ${{ github.event_name == 'pull_request' }}
-      uses: tamu-edu/it-ae-actions-terraform-pr-commenter@dev
+    - name: Post Terraform init failure
+      if: ${{ failure() && (github.event_name == 'pull_request') }}
+      uses: actions/github-script@v7
       with:
-        commenter_type: init
-        commenter_input: ${{ format('{0}{1}', steps.init.outputs.stdout, steps.init.outputs.stderr) }}
-        commenter_exitcode: ${{ steps.init.outputs.exitcode }}
-      env:
-        GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
-        TF_WORKSPACE: ${{ inputs.terraform-workspace }}
+        github-token: ${{ inputs.GITHUB_TOKEN }}
+        script: |
+          github.rest.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: `# Terraform Init Failure
+              ## ${{ inputs.header }}
 
+              ## Details
+              - **Workflow Header**: ${{ inputs.header }}
+              - **Job ID**: ${{ github.job }}
+              - **Step**: terraform init
+              - **Status**: Failed
+              
+
+              ## Error output
+              ${{ steps.init.outputs.stdout}}
+              ${{ steps.init.outputs.stderr}}`
+          })
+          core.setFailed('The terraform init step failed.');
+          
     - name: Terraform Plan
       id: plan
       shell: bash
@@ -89,31 +109,13 @@ runs:
         terraform plan -out=tfplan -input=false ${{ inputs.terraform-plan-flags }}
       continue-on-error: true
 
-    - name: generate tf-summarize table
-      id: summary
-      shell: bash
-      working-directory: ${{ inputs.working-directory }}
-      env:
-        TF_WORKSPACE: ${{ inputs.terraform-workspace }}
-      run: |
-        EOF=$(openssl rand -hex 8)
-
-        echo "table<<$EOF" >> $GITHUB_OUTPUT
-        terraform-bin show -json tfplan | tf-summarize -md >> $GITHUB_OUTPUT
-        echo "$EOF" >> $GITHUB_OUTPUT
-
-    - name: Post terraform plan
-      if: ${{ github.event_name == 'pull_request' }}
-      uses: tamu-edu/it-ae-actions-terraform-pr-commenter@dev
+    - name: Post PR comment
+      uses: borchero/terraform-plan-comment@v2
       with:
-        commenter_type: plan
-        commenter_input: ${{ format('{0}{1}', steps.plan.outputs.stdout, steps.plan.outputs.stderr) }}
-        commenter_exitcode: ${{ steps.plan.outputs.exitcode }}
-        comment_prepend: ${{ steps.summary.outputs.table }}
-      env:
-        GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
-        TF_WORKSPACE: ${{ inputs.terraform-workspace }}
-
+        header: ${{ inputs.header }}
+        token: ${{ inputs.GITHUB_TOKEN }}
+        planfile: tfplan
+        
     - name: Save Artifact
       id: save-artifact
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
Joseph pointed me to some work he had done in `feature/new-commenter-action`, so I continued it here in `feature/new-commenter-action-continued` for this PR. Thanks Joseph - The new plan/commenter/upload composite actions does a whole lot more and whole lot cleaner. Implementing on a client project has been largely drop-in-place (see [a run here](https://github.com/tamu-edu/it-eas-reviewem-iac/actions/runs/18477977373/job/52648483427)).

In a word: Exceptional! Covers all identified use cases:
* Doesn't blow up on large plan (bc it operates off a a `tfplan` file, not silly text passing)
* Abandons 2 year old stale fork
* Looks much better

Additionally, I:
* Removed the superfluous artifacts upload block from our composite action
* Am passing in `inputs.save-artifacts` to the new composite action's built-in `upload-plan` (1:1 string boolean) and have confirmed both cases in testing
* Updated README.md of old inputs (we aren't _directly_ using init flags anymore, and the composite action only relies on `env.TF_CLI_ARGS`)
* Cleared out commented out blocks of code

Fixes #13 